### PR TITLE
Add goreleaser, split CI into presubmit and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,40 +1,18 @@
-name: Cross Platform Build
+name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    tags:
-      - v*
     branches:
-      - master
+      - main
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-      id: checkout
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: stable
-
-    - name: Get dependencies and run test
-      run: |
-        go test -race ./...
-
-    - name: Build
-      if: startsWith(github.ref, 'refs/tags/')
-      run: make -j releases
-
-    - name: Upload Release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        files: kt-v*
-        draft: false
-        prerelease: false
+    - run: go test -race ./...
+    - run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types: [created]
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    tags:
+      - v*
+permissions:
+  contents: write
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable
+    - uses: goreleaser/goreleaser-action@v6
+      with:
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,33 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/knight42/kt/pkg/version.Version={{.Version}}
+      - -X github.com/knight42/kt/pkg/version.BuildDate={{.Date}}
+      - -X github.com/knight42/kt/pkg/version.GitCommit={{.Commit}}
+    flags:
+      - -trimpath
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,5 +29,8 @@ archives:
 checksum:
   name_template: checksums.txt
 
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
 changelog:
-  sort: asc
+  use: github-native


### PR DESCRIPTION
## Summary
- Split single `build.yml` workflow into two: `build.yml` (presubmit: test + build on PRs/main) and `release.yml` (goreleaser on tag pushes)
- Add `.goreleaser.yml` with cross-compilation for linux/darwin/windows on amd64/arm64 (adds arm64 support)
- Fix workflow branch reference from `master` to `main`

## Test plan
- [ ] Push to main triggers CI test job
- [ ] Tagging `v*` triggers release workflow with goreleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)