### PR TITLE
Replace --no-prefix with --prefix=auto|always|off

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	flags.BoolVar(&o.timestamps, "timestamps", o.timestamps, "Include timestamps on each line in the log output")
 	flags.BoolVar(&o.previous, "previous", false, "If true, print the logs for the previous instance of the container in a pod if it exists.")
 	flags.BoolVar(&o.exitWithPods, "exit-with-pods", false, "Exit if all watched pods are deleted.")
-	flags.BoolVar(&o.noPrefix, "no-prefix", false, "Display original log without prefix.")
+	flags.StringVar(&o.prefix, "prefix", "auto", "When to show the pod/container prefix. One of: auto|always|off")
 	flags.StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Only one of since-time / since may be used.")
 	flags.StringVar(&o.color, "color", "auto", "Colorize the output. One of: auto|always|never")
 	flags.DurationVar(&o.sinceSeconds, "since", o.sinceSeconds, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")

--- a/options.go
+++ b/options.go
@@ -22,7 +22,7 @@ type Options struct {
 	previous     bool
 	timestamps   bool
 	exitWithPods bool
-	noPrefix     bool
+	prefix       string
 	tail         int64
 	container    string
 	nodeName     string
@@ -55,6 +55,12 @@ func (o *Options) Complete(getter genericclioptions.RESTClientGetter, args []str
 	case "auto", "always", "never":
 	default:
 		return fmt.Errorf("unknown value of flag `color`: %s", o.color)
+	}
+
+	switch o.prefix {
+	case "auto", "always", "off":
+	default:
+		return fmt.Errorf("unknown value of flag `prefix`: %s", o.prefix)
 	}
 
 	switch len(args) {
@@ -115,7 +121,7 @@ func (o *Options) Run(cmd *cobra.Command) error {
 		controller.WithPodNameRegexp(o.podNamePattern),
 		controller.WithContainerNameRegexp(o.containerNamePattern),
 		controller.EnableExitWithPods(o.exitWithPods),
-		controller.WithPrefix(!o.noPrefix),
+		controller.WithPrefixMode(o.prefix),
 		controller.WithNodeName(o.nodeName),
 	)
 	return c.Run()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sync/atomic"
 
 	"github.com/fatih/color"
 	corev1 "k8s.io/api/core/v1"
@@ -27,10 +28,11 @@ type Controller struct {
 	color        string
 	nodeName     string
 	exitWithPods bool
-	showPrefix   bool
+	prefixMode   string
 	logsOptions  *corev1.PodLogOptions
 
-	enableColor bool
+	enableColor        bool
+	singlePodContainer atomic.Bool
 
 	labelSelector string
 
@@ -172,6 +174,7 @@ func (c *Controller) onPodAdded(pod *corev1.Pod) {
 	)
 	t.Tail()
 	c.podsTailer[pod.UID] = t
+	c.updatePrefixState()
 }
 
 func (c *Controller) onPodModified(pod *corev1.Pod) {
@@ -189,12 +192,37 @@ func (c *Controller) onPodDeleted(pod *corev1.Pod) {
 	}
 	t.Close()
 	delete(c.podsTailer, pod.UID)
+	c.updatePrefixState()
+}
+
+func (c *Controller) updatePrefixState() {
+	if c.prefixMode != "auto" {
+		return
+	}
+	single := len(c.podsTailer) == 1
+	if single {
+		for _, t := range c.podsTailer {
+			single = t.ContainerCount() == 1
+		}
+	}
+	c.singlePodContainer.Store(single)
+}
+
+func (c *Controller) shouldShowPrefix() bool {
+	switch c.prefixMode {
+	case "always":
+		return true
+	case "off":
+		return false
+	default:
+		return !c.singlePodContainer.Load()
+	}
 }
 
 func (c *Controller) consumeLog() {
 	w := bufio.NewWriter(os.Stdout)
 	for i := range c.logCh {
-		if c.showPrefix {
+		if c.shouldShowPrefix() {
 			if i.PodColor != nil {
 				_, _ = i.PodColor.Fprint(w, i.Pod)
 				_, _ = i.ContainerColor.Fprintf(w, "[%s] ", i.Container)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -41,7 +41,8 @@ type Controller struct {
 	podNameRegex       *regexp.Regexp
 	containerNameRegex *regexp.Regexp
 
-	podsTailer map[types.UID]tailer.Tailer
+	podsTailer   map[types.UID]tailer.Tailer
+	newTailerFn  func(ns, name string, ctNames map[string]struct{}, enableColor bool, client kubernetes.Interface, logsOptions *corev1.PodLogOptions, logCh chan<- *api.Log) tailer.Tailer
 }
 
 func New(f genericclioptions.RESTClientGetter, logsOpts *corev1.PodLogOptions, opts ...Option) *Controller {
@@ -50,6 +51,7 @@ func New(f genericclioptions.RESTClientGetter, logsOpts *corev1.PodLogOptions, o
 		logCh:       make(chan *api.Log, 1),
 		logsOptions: logsOpts,
 		podsTailer:  make(map[types.UID]tailer.Tailer),
+		newTailerFn: tailer.New,
 	}
 	for _, o := range opts {
 		o(c)
@@ -164,7 +166,7 @@ func (c *Controller) onPodAdded(pod *corev1.Pod) {
 		log.V(4).Infof(">>>>> [DEBUG] no container found for pod: %s regex: %s", pod.Name, c.containerNameRegex)
 		return
 	}
-	t := tailer.New(
+	t := c.newTailerFn(
 		c.namespace, pod.Name,
 		names,
 		c.enableColor,
@@ -172,9 +174,9 @@ func (c *Controller) onPodAdded(pod *corev1.Pod) {
 		c.logsOptions,
 		c.logCh,
 	)
-	t.Tail()
 	c.podsTailer[pod.UID] = t
 	c.updatePrefixState()
+	t.Tail()
 }
 
 func (c *Controller) onPodModified(pod *corev1.Pod) {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -3,20 +3,29 @@ package controller
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 
+	"github.com/knight42/kt/pkg/api"
 	"github.com/knight42/kt/pkg/tailer"
 )
 
 type fakeTailer struct {
 	containerCount int
+	onTail         func()
 }
 
-func (f *fakeTailer) Tail()                       {}
-func (f *fakeTailer) TailSync()                   {}
+func (f *fakeTailer) Tail() {
+	if f.onTail != nil {
+		f.onTail()
+	}
+}
+func (f *fakeTailer) TailSync()                    {}
 func (f *fakeTailer) RetryContainers(names []string) {}
-func (f *fakeTailer) ContainerCount() int         { return f.containerCount }
-func (f *fakeTailer) Close()                      {}
+func (f *fakeTailer) ContainerCount() int          { return f.containerCount }
+func (f *fakeTailer) Close()                       {}
 
 var _ tailer.Tailer = (*fakeTailer)(nil)
 
@@ -76,6 +85,47 @@ func TestShouldShowPrefix_Auto(t *testing.T) {
 				t.Errorf("shouldShowPrefix() = %v, want %v", got, tt.wantPrefix)
 			}
 		})
+	}
+}
+
+func TestOnPodAdded_PrefixStateSetBeforeTail(t *testing.T) {
+	tailCalled := false
+	prefixCorrectAtTailTime := false
+
+	c := &Controller{
+		prefixMode:  "auto",
+		podsTailer:  make(map[types.UID]tailer.Tailer),
+		logCh:       make(chan *api.Log, 1),
+		logsOptions: &corev1.PodLogOptions{},
+	}
+	c.newTailerFn = func(ns, name string, ctNames map[string]struct{}, enableColor bool, client kubernetes.Interface, logsOptions *corev1.PodLogOptions, logCh chan<- *api.Log) tailer.Tailer {
+		ft := &fakeTailer{containerCount: len(ctNames)}
+		ft.onTail = func() {
+			tailCalled = true
+			prefixCorrectAtTailTime = !c.shouldShowPrefix()
+		}
+		return ft
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+			UID:  "uid-1",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app"},
+			},
+		},
+	}
+
+	c.onPodAdded(pod)
+
+	if !tailCalled {
+		t.Fatal("Tail() was not called")
+	}
+	if !prefixCorrectAtTailTime {
+		t.Error("prefix state must be set before Tail(); single pod with single container should hide prefix at Tail() time")
 	}
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/knight42/kt/pkg/tailer"
+)
+
+type fakeTailer struct {
+	containerCount int
+}
+
+func (f *fakeTailer) Tail()                       {}
+func (f *fakeTailer) TailSync()                   {}
+func (f *fakeTailer) RetryContainers(names []string) {}
+func (f *fakeTailer) ContainerCount() int         { return f.containerCount }
+func (f *fakeTailer) Close()                      {}
+
+var _ tailer.Tailer = (*fakeTailer)(nil)
+
+func TestShouldShowPrefix_Always(t *testing.T) {
+	c := &Controller{prefixMode: "always"}
+	if !c.shouldShowPrefix() {
+		t.Error("expected prefix to show in always mode")
+	}
+}
+
+func TestShouldShowPrefix_Off(t *testing.T) {
+	c := &Controller{prefixMode: "off"}
+	if c.shouldShowPrefix() {
+		t.Error("expected prefix to be hidden in off mode")
+	}
+}
+
+func TestShouldShowPrefix_Auto(t *testing.T) {
+	tests := map[string]struct {
+		pods       map[types.UID]tailer.Tailer
+		wantPrefix bool
+	}{
+		"no pods": {
+			pods:       map[types.UID]tailer.Tailer{},
+			wantPrefix: true,
+		},
+		"single pod single container": {
+			pods: map[types.UID]tailer.Tailer{
+				"uid-1": &fakeTailer{containerCount: 1},
+			},
+			wantPrefix: false,
+		},
+		"single pod multiple containers": {
+			pods: map[types.UID]tailer.Tailer{
+				"uid-1": &fakeTailer{containerCount: 2},
+			},
+			wantPrefix: true,
+		},
+		"multiple pods": {
+			pods: map[types.UID]tailer.Tailer{
+				"uid-1": &fakeTailer{containerCount: 1},
+				"uid-2": &fakeTailer{containerCount: 1},
+			},
+			wantPrefix: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Controller{
+				prefixMode: "auto",
+				podsTailer: tt.pods,
+			}
+			c.updatePrefixState()
+			got := c.shouldShowPrefix()
+			if got != tt.wantPrefix {
+				t.Errorf("shouldShowPrefix() = %v, want %v", got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestUpdatePrefixState_SkipsNonAuto(t *testing.T) {
+	modes := map[string]struct{}{
+		"always": {},
+		"off":    {},
+	}
+	for mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			c := &Controller{
+				prefixMode: mode,
+				podsTailer: map[types.UID]tailer.Tailer{
+					"uid-1": &fakeTailer{containerCount: 1},
+				},
+			}
+			c.singlePodContainer.Store(false)
+			c.updatePrefixState()
+			if c.singlePodContainer.Load() {
+				t.Error("updatePrefixState should not modify state for non-auto mode")
+			}
+		})
+	}
+}

--- a/pkg/controller/option.go
+++ b/pkg/controller/option.go
@@ -36,9 +36,9 @@ func EnableExitWithPods(enable bool) Option {
 	}
 }
 
-func WithPrefix(enable bool) Option {
+func WithPrefixMode(mode string) Option {
 	return func(t *Controller) {
-		t.showPrefix = enable
+		t.prefixMode = mode
 	}
 }
 

--- a/pkg/tailer/tailer.go
+++ b/pkg/tailer/tailer.go
@@ -17,6 +17,7 @@ type Tailer interface {
 	Tail()
 	TailSync()
 	RetryContainers(names []string)
+	ContainerCount() int
 	Close()
 }
 
@@ -134,6 +135,10 @@ func (t *tailer) RetryContainers(names []string) {
 	if len(retried) > 0 {
 		log.V(5).Infof(">>>>> [DEBUG] modified pod: %s, retryable containers: %v", t.podName, retried)
 	}
+}
+
+func (t *tailer) ContainerCount() int {
+	return len(t.ctNames)
 }
 
 func (t *tailer) Close() {


### PR DESCRIPTION
## Summary
- Replace boolean `--no-prefix` flag with `--prefix=auto|always|off` (default: `auto`)
- **auto**: hides prefix when tailing a single pod with a single container; dynamically adjusts as pods are added/removed
- **always**: always show the pod/container prefix (previous default behavior)
- **off**: never show prefix (equivalent to old `--no-prefix`)

## Implementation
- `Controller` uses an `atomic.Bool` to track single-pod-single-container state, updated on pod add/delete events
- `Tailer` interface gains `ContainerCount()` to support the auto check
- Consumer goroutine reads the atomic without locking

## Test plan
- [ ] `kt --prefix=always deploy foo` always shows prefix
- [ ] `kt --prefix=off deploy foo` never shows prefix
- [ ] `kt deploy foo` (auto) hides prefix for single-pod/single-container, shows when a second pod appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)