### PR TITLE
Drop --exit-with-pods and --previous flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,8 +71,6 @@ func main() {
 	flags.StringVarP(&o.container, "container", "c", o.container, "Regular expression to match container names.")
 	flags.Int64Var(&o.tail, "tail", 10, "Lines of recent log file to display. Defaults to 10. If set to 0 it will return all logs.")
 	flags.BoolVar(&o.timestamps, "timestamps", o.timestamps, "Include timestamps on each line in the log output")
-	flags.BoolVar(&o.previous, "previous", false, "If true, print the logs for the previous instance of the container in a pod if it exists.")
-	flags.BoolVar(&o.exitWithPods, "exit-with-pods", false, "Exit if all watched pods are deleted.")
 	flags.StringVar(&o.prefix, "prefix", "auto", "When to show the pod/container prefix. One of: auto|always|off")
 	flags.StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Only one of since-time / since may be used.")
 	flags.StringVar(&o.color, "color", "auto", "Colorize the output. One of: auto|always|never")

--- a/options.go
+++ b/options.go
@@ -19,10 +19,8 @@ type Options struct {
 	selector     string
 	sinceSeconds time.Duration
 	sinceTime    string
-	previous     bool
-	timestamps   bool
-	exitWithPods bool
-	prefix       string
+	timestamps bool
+	prefix string
 	tail         int64
 	container    string
 	nodeName     string
@@ -120,7 +118,6 @@ func (o *Options) Run(cmd *cobra.Command) error {
 		controller.WithPodLabelsSelector(o.selector),
 		controller.WithPodNameRegexp(o.podNamePattern),
 		controller.WithContainerNameRegexp(o.containerNamePattern),
-		controller.EnableExitWithPods(o.exitWithPods),
 		controller.WithPrefixMode(o.prefix),
 		controller.WithNodeName(o.nodeName),
 	)
@@ -129,9 +126,8 @@ func (o *Options) Run(cmd *cobra.Command) error {
 
 func (o *Options) toLogsOptions() (corev1.PodLogOptions, error) {
 	opt := corev1.PodLogOptions{
-		Follow:     !o.previous,
+		Follow:     true,
 		Timestamps: o.timestamps,
-		Previous:   o.previous,
 	}
 	if len(o.sinceTime) > 0 {
 		t, err := parseRFC3339(o.sinceTime)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,8 +27,7 @@ type Controller struct {
 	namespace    string
 	color        string
 	nodeName     string
-	exitWithPods bool
-	prefixMode   string
+	prefixMode string
 	logsOptions  *corev1.PodLogOptions
 
 	enableColor        bool
@@ -110,23 +109,6 @@ func (c *Controller) Run() error {
 
 	byName := c.podNameRegex != nil
 
-	if c.logsOptions.Previous {
-		err := result.Visit(func(info *resource.Info, err error) error {
-			pod, ok := info.Object.(*corev1.Pod)
-			if !ok {
-				return nil
-			}
-			if byName && !c.podNameRegex.MatchString(pod.Name) {
-				return nil
-			}
-			log.Errorf("+ [%s] pod added", pod.Name)
-			c.onPodAdded(pod)
-			c.podsTailer[pod.UID].TailSync()
-			return nil
-		})
-		return err
-	}
-
 	watcher, err := result.Watch("")
 	if err != nil {
 		return err
@@ -151,9 +133,6 @@ func (c *Controller) Run() error {
 		case watch.Deleted:
 			log.Errorf("- [%s] pod deleted", pod.Name)
 			c.onPodDeleted(pod)
-			if c.exitWithPods && len(c.podsTailer) == 0 {
-				return nil
-			}
 		}
 	}
 	return nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -22,7 +22,6 @@ func (f *fakeTailer) Tail() {
 		f.onTail()
 	}
 }
-func (f *fakeTailer) TailSync()                    {}
 func (f *fakeTailer) RetryContainers(names []string) {}
 func (f *fakeTailer) ContainerCount() int          { return f.containerCount }
 func (f *fakeTailer) Close()                       {}

--- a/pkg/controller/option.go
+++ b/pkg/controller/option.go
@@ -30,12 +30,6 @@ func WithColor(when string) Option {
 	}
 }
 
-func EnableExitWithPods(enable bool) Option {
-	return func(t *Controller) {
-		t.exitWithPods = enable
-	}
-}
-
 func WithPrefixMode(mode string) Option {
 	return func(t *Controller) {
 		t.prefixMode = mode

--- a/pkg/tailer/tailer.go
+++ b/pkg/tailer/tailer.go
@@ -15,7 +15,6 @@ import (
 
 type Tailer interface {
 	Tail()
-	TailSync()
 	RetryContainers(names []string)
 	ContainerCount() int
 	Close()
@@ -70,12 +69,6 @@ func (t *tailer) Tail() {
 		k := t.newTask(ct)
 		t.tasks[ct] = k
 		go k.Job()
-	}
-}
-
-func (t *tailer) TailSync() {
-	for ct := range t.ctNames {
-		t.newTask(ct).Job()
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove `--exit-with-pods` flag and early-exit logic
- Remove `--previous` flag, synchronous `TailSync` code path, and `TailSync` from the `Tailer` interface
- `Follow` is now always `true` in log options

🤖 Generated with [Claude Code](https://claude.com/claude-code)