### PR TITLE
Update README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,22 @@ kt (Kubernetes Tail) is a CLI tool that streams logs from Kubernetes pods, simil
 ## Build & Install
 
 ```bash
+make build            # local build with version ldflags
 make install          # go install with version ldflags
 go build .            # quick local build without version info
-make darwin-amd64     # cross-compile for a specific platform
-make all              # build darwin-amd64, linux-amd64, windows-amd64
-make releases         # tar.gz + zip archives for distribution
 ```
 
+Cross-platform builds and releases are handled by goreleaser (`.goreleaser.yml`), triggered by the release workflow on GitHub release creation.
+
 Version info (Version, BuildDate, GitCommit) is injected via ldflags defined in the Makefile into `pkg/version`.
+
+## Tests
+
+```bash
+go test ./...                          # run all tests
+go test ./pkg/query/ -v                # run a specific package
+go test ./pkg/controller/ -run TestFoo # run a specific test
+```
 
 ## Architecture
 
@@ -25,8 +33,9 @@ The codebase follows a pipeline: **CLI parsing -> resource resolution -> watch l
 - **Root command** (`main.go`): Single cobra command. Parses flags, delegates to `Options.Complete` then `Options.Run`.
 - **Options** (`options.go`): Resolves CLI args into either a pod name regexp (1 arg) or a label selector (2 args: resource type + name, or `-l` flag). For higher-level resources, it fetches the object and extracts the pod selector via `getPodsSelector` in `helpers.go`.
 - **helpers.go**: Maps Kubernetes resource types to their pod label selectors. HPA is resolved recursively by following `scaleTargetRef` to the underlying workload. Uses `k8s.io/cli-runtime/pkg/resource.Builder` for server-side resource fetching.
-- **Controller** (`pkg/controller/`): Watches pods matching the resolved selector/name. On Added/Modified/Deleted events, creates or manages per-pod `Tailer` instances. A single goroutine (`consumeLog`) drains the shared log channel to stdout with buffered writes and optional color prefixes. Configured via functional options (`option.go`).
+- **Controller** (`pkg/controller/`): Watches pods matching the resolved selector/name. On Added/Modified/Deleted events, creates or manages per-pod `Tailer` instances. A single goroutine (`consumeLog`) drains the shared log channel to stdout with buffered writes and optional color prefixes. Configured via functional options (`option.go`). Tailer creation is injectable via `newTailerFn` for testing.
 - **Tailer** (`pkg/tailer/`): Per-pod log streamer. Creates a `Task` per container, each running `fetchLog` in its own goroutine. `fetchLog` uses the Kubernetes streaming logs API. Supports retry on container restart (triggered by the controller on Modified events). The tailer owns a root context; `Close()` cancels all container tasks.
+- **Query** (`pkg/query/`): Recursive descent parser for the `-q/--query` log filter DSL. Supports keywords (case-insensitive substring), `and`/`or` operators (`and` binds tighter), parentheses, and quoted strings.
 - **api.Log** (`pkg/api/types.go`): The message struct passed through the log channel from tailers to the controller's consumer.
 - **pkg/log**: Minimal leveled logger (V-style verbosity) writing to stderr. `-v` flag controls debug output.
 
@@ -39,4 +48,5 @@ Group related changes into separate commits (e.g., don't mix dependency updates 
 - Pod selection has two paths: by name regexp (watches all pods, filters client-side) vs. by label selector (server-side filtering). These are mutually exclusive.
 - The controller uses a `map[types.UID]tailer.Tailer` to track active pods. Each tailer manages a `map[string]*Task` for its containers.
 - Color assignment happens once per pod at tailer creation time via `pickColor()`.
-- The `--previous` flag disables the watch loop entirely and uses synchronous `TailSync()` instead.
+- **Ordering invariant**: in `onPodAdded`, the pod must be added to `podsTailer` and `updatePrefixState` must be called BEFORE `t.Tail()`. This prevents a race where tailer goroutines send logs before prefix state is set. There is a regression test for this.
+- Table-driven tests use `map[string]struct{}` style, not `[]struct{name string}`, to avoid order dependency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# kt ![](https://github.com/knight42/kt/workflows/Cross%20Platform%20Build/badge.svg)
+# kt ![](https://github.com/knight42/kt/workflows/CI/badge.svg)
 
-kt is short for Kubernetes Tail. It behaves like `kubect logs -f` and
+kt is short for Kubernetes Tail. It behaves like `kubectl logs -f` and
 its usage is similar to `kubectl get`.
 
 # Table of Contents
@@ -10,8 +10,10 @@ its usage is similar to `kubectl get`.
     * [1.1 Install bash/zsh completion](#11-install-bashzsh-completion)
     * [1.2 Filter pods by name or regexp](#12-filter-pods-by-name-or-regexp)
     * [1.3 Filter pods by labels](#13-filter-pods-by-labels)
-    * [1.4 Tails pods belong to a higher level object](#14-tails-pods-belong-to-a-higher-level-object)
-* [2. Installtion](#2-installtion)
+    * [1.4 Tail pods belong to a higher level object](#14-tails-pods-belong-to-a-higher-level-object)
+    * [1.5 Filter logs by query](#15-filter-logs-by-query)
+    * [1.6 Prefix mode](#16-prefix-mode)
+* [2. Installation](#2-installation)
 
 # 0. Features
 
@@ -19,6 +21,8 @@ its usage is similar to `kubectl get`.
 * Automatically tail new pods, discard deleted pods and retry if the pod
 switches to running phase from pending phase.
 * Recover from containers restart.
+* Filter logs by query DSL with `and`, `or`, parentheses, and quoted strings.
+* Auto-hide pod/container prefix when tailing a single container.
 * Auto completion.
 * Colorized output.
 
@@ -64,7 +68,7 @@ Currently only the following resources are supported:
 * Job
 * ReplicaSet
 * ReplicationController
-* Cronjob(partially supported. You must specify labels in the pod template.)
+* CronJob
 
 ```
 $ kt hpa foo
@@ -81,7 +85,38 @@ $ kt --context prod ds foo
 $ kt --cluster dev job foo
 ```
 
-# 2. Installtion
+#### 1.5 Filter logs by query
+
+Use `-q/--query` to filter log lines with a boolean DSL:
+
+```
+# Match lines containing both keywords
+$ kt deploy foo -q 'error and timeout'
+
+# Match lines containing either keyword
+$ kt deploy foo -q 'error or warning'
+
+# Use parentheses to group expressions (and binds tighter than or)
+$ kt deploy foo -q '(error or warn) and timeout'
+
+# Use quotes for keywords with spaces
+$ kt deploy foo -q '"error code" and 500'
+```
+
+#### 1.6 Prefix mode
+
+The `--prefix` flag controls pod/container prefix display:
+
+* `auto` (default): hide prefix when tailing a single pod with a single container
+* `always`: always show the prefix
+* `off`: never show the prefix
+
+```
+$ kt deploy foo --prefix=always
+$ kt deploy foo --prefix=off
+```
+
+# 2. Installation
 
 Using Homebrew:
 ```


### PR DESCRIPTION
## Summary
- **README**: Add query filter and prefix mode sections, fix workflow badge name, fix typos, remove references to dropped flags
- **CLAUDE.md**: Fix stale references (removed --previous/TailSync, old Makefile targets), add query package to architecture, document onPodAdded ordering invariant and test style convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)