### PR TITLE
Highlight query matches and unify flag enums

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 	flags.StringVarP(&o.container, "container", "c", o.container, "Regular expression to match container names.")
 	flags.Int64Var(&o.tail, "tail", 10, "Lines of recent log file to display. Defaults to 10. If set to 0 it will return all logs.")
 	flags.BoolVar(&o.timestamps, "timestamps", o.timestamps, "Include timestamps on each line in the log output")
-	flags.StringVar(&o.prefix, "prefix", "auto", "When to show the pod/container prefix. One of: auto|always|off")
+	flags.StringVar(&o.prefix, "prefix", "auto", "When to show the pod/container prefix. One of: auto|always|never")
 	flags.StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Only one of since-time / since may be used.")
 	flags.StringVar(&o.color, "color", "auto", "Colorize the output. One of: auto|always|never")
 	flags.DurationVar(&o.sinceSeconds, "since", o.sinceSeconds, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")

--- a/options.go
+++ b/options.go
@@ -60,7 +60,7 @@ func (o *Options) Complete(getter genericclioptions.RESTClientGetter, args []str
 	}
 
 	switch o.prefix {
-	case "auto", "always", "off":
+	case "auto", "always", "never":
 	default:
 		return fmt.Errorf("unknown value of flag `prefix`: %s", o.prefix)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -195,7 +195,7 @@ func (c *Controller) shouldShowPrefix() bool {
 	switch c.prefixMode {
 	case "always":
 		return true
-	case "off":
+	case "never":
 		return false
 	default:
 		return !c.singlePodContainer.Load()
@@ -203,6 +203,10 @@ func (c *Controller) shouldShowPrefix() bool {
 }
 
 func (c *Controller) consumeLog() {
+	var queryTerms [][]byte
+	if c.queryExpr != nil {
+		queryTerms = c.queryExpr.Terms()
+	}
 	w := bufio.NewWriter(os.Stdout)
 	for i := range c.logCh {
 		if c.queryExpr != nil && !c.queryExpr.Match(i.Content) {
@@ -216,7 +220,11 @@ func (c *Controller) consumeLog() {
 				_, _ = w.WriteString(i.Pod + "[" + i.Container + "] ")
 			}
 		}
-		_, _ = w.Write(i.Content)
+		content := i.Content
+		if len(queryTerms) > 0 && c.enableColor {
+			content = query.Highlight(content, queryTerms)
+		}
+		_, _ = w.Write(content)
 		_ = w.Flush()
 	}
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -36,7 +36,7 @@ func TestShouldShowPrefix_Always(t *testing.T) {
 }
 
 func TestShouldShowPrefix_Off(t *testing.T) {
-	c := &Controller{prefixMode: "off"}
+	c := &Controller{prefixMode: "never"}
 	if c.shouldShowPrefix() {
 		t.Error("expected prefix to be hidden in off mode")
 	}
@@ -131,7 +131,7 @@ func TestOnPodAdded_PrefixStateSetBeforeTail(t *testing.T) {
 func TestUpdatePrefixState_SkipsNonAuto(t *testing.T) {
 	modes := map[string]struct{}{
 		"always": {},
-		"off":    {},
+		"never":  {},
 	}
 	for mode := range modes {
 		t.Run(mode, func(t *testing.T) {

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -2,12 +2,14 @@ package query
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"unicode"
 )
 
 type Expr interface {
 	Match(line []byte) bool
+	Terms() [][]byte
 }
 
 type keyword struct {
@@ -18,6 +20,10 @@ func (k *keyword) Match(line []byte) bool {
 	return bytesContainsFold(line, k.term)
 }
 
+func (k *keyword) Terms() [][]byte {
+	return [][]byte{k.term}
+}
+
 type andExpr struct {
 	left, right Expr
 }
@@ -26,12 +32,20 @@ func (a *andExpr) Match(line []byte) bool {
 	return a.left.Match(line) && a.right.Match(line)
 }
 
+func (a *andExpr) Terms() [][]byte {
+	return append(a.left.Terms(), a.right.Terms()...)
+}
+
 type orExpr struct {
 	left, right Expr
 }
 
 func (o *orExpr) Match(line []byte) bool {
 	return o.left.Match(line) || o.right.Match(line)
+}
+
+func (o *orExpr) Terms() [][]byte {
+	return append(o.left.Terms(), o.right.Terms()...)
 }
 
 // Parse parses a query DSL string into an Expr.
@@ -226,4 +240,42 @@ func equalFold(a, b []byte) bool {
 		}
 	}
 	return true
+}
+
+var (
+	highlightStart = []byte("\033[1;31m")
+	highlightReset = []byte("\033[0m")
+)
+
+func Highlight(line []byte, terms [][]byte) []byte {
+	if len(terms) == 0 {
+		return line
+	}
+	sorted := make([][]byte, len(terms))
+	copy(sorted, terms)
+	sort.Slice(sorted, func(i, j int) bool {
+		return len(sorted[i]) > len(sorted[j])
+	})
+
+	var buf []byte
+	i := 0
+	for i < len(line) {
+		matched := false
+		for _, term := range sorted {
+			tl := len(term)
+			if i+tl <= len(line) && equalFold(line[i:i+tl], term) {
+				buf = append(buf, highlightStart...)
+				buf = append(buf, line[i:i+tl]...)
+				buf = append(buf, highlightReset...)
+				i += tl
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			buf = append(buf, line[i])
+			i++
+		}
+	}
+	return buf
 }

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -1,6 +1,9 @@
 package query
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestParse_Match(t *testing.T) {
 	tests := map[string]struct {
@@ -127,6 +130,128 @@ func TestParse_Errors(t *testing.T) {
 			_, err := Parse(input)
 			if err == nil {
 				t.Errorf("Parse(%q) expected error, got nil", input)
+			}
+		})
+	}
+}
+
+func TestTerms(t *testing.T) {
+	tests := map[string]struct {
+		query string
+		want  []string
+	}{
+		"single keyword": {
+			query: "error",
+			want:  []string{"error"},
+		},
+		"and expression": {
+			query: "error and fatal",
+			want:  []string{"error", "fatal"},
+		},
+		"or expression": {
+			query: "error or warning",
+			want:  []string{"error", "warning"},
+		},
+		"nested": {
+			query: "(a or b) and c",
+			want:  []string{"a", "b", "c"},
+		},
+		"quoted keyword": {
+			query: `"error code" and fatal`,
+			want:  []string{"error code", "fatal"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			expr, err := Parse(tt.query)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.query, err)
+			}
+			got := expr.Terms()
+			if len(got) != len(tt.want) {
+				t.Fatalf("Terms() returned %d terms, want %d", len(got), len(tt.want))
+			}
+			for i, want := range tt.want {
+				if !bytes.Equal(got[i], []byte(want)) {
+					t.Errorf("Terms()[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestHighlight(t *testing.T) {
+	hl := func(s string) string {
+		return "\033[1;31m" + s + "\033[0m"
+	}
+
+	tests := map[string]struct {
+		line  string
+		terms []string
+		want  string
+	}{
+		"no terms": {
+			line:  "hello world",
+			terms: nil,
+			want:  "hello world",
+		},
+		"single match": {
+			line:  "an error occurred",
+			terms: []string{"error"},
+			want:  "an " + hl("error") + " occurred",
+		},
+		"case insensitive": {
+			line:  "an ERROR occurred",
+			terms: []string{"error"},
+			want:  "an " + hl("ERROR") + " occurred",
+		},
+		"multiple terms": {
+			line:  "fatal error occurred",
+			terms: []string{"fatal", "error"},
+			want:  hl("fatal") + " " + hl("error") + " occurred",
+		},
+		"no match": {
+			line:  "all good",
+			terms: []string{"error"},
+			want:  "all good",
+		},
+		"overlapping prefers longer": {
+			line:  "error_code found",
+			terms: []string{"err", "error_code"},
+			want:  hl("error_code") + " found",
+		},
+		"multiple occurrences": {
+			line:  "error and error again",
+			terms: []string{"error"},
+			want:  hl("error") + " and " + hl("error") + " again",
+		},
+		"match at start": {
+			line:  "error!",
+			terms: []string{"error"},
+			want:  hl("error") + "!",
+		},
+		"match at end": {
+			line:  "got error",
+			terms: []string{"error"},
+			want:  "got " + hl("error"),
+		},
+		"quoted multi-word term": {
+			line:  "fatal error code 500",
+			terms: []string{"error code"},
+			want:  "fatal " + hl("error code") + " 500",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var terms [][]byte
+			for _, s := range tt.terms {
+				terms = append(terms, []byte(s))
+			}
+			got := Highlight([]byte(tt.line), terms)
+			if !bytes.Equal(got, []byte(tt.want)) {
+				t.Errorf("Highlight() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Highlight `-q/--query` term matches in bold red ANSI in log output, respecting `--color` flag (only when `auto` on tty or `always`)
- Unify `--prefix` enum from `auto|always|off` to `auto|always|never` to match `--color`

## Test plan
- [x] `TestTerms` — verifies keyword extraction from single, and, or, nested, and quoted expressions
- [x] `TestHighlight` — 10 cases: single/multiple matches, case insensitivity, longest-match-first, boundary positions, multi-word terms, no-match passthrough
- [x] Existing `TestShouldShowPrefix_Off` and `TestUpdatePrefixState_SkipsNonAuto` updated for `never`
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)