### PR TITLE
Accept on/off/yes/no as --color flag values

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	flags.BoolVar(&o.timestamps, "timestamps", o.timestamps, "Include timestamps on each line in the log output")
 	flags.StringVar(&o.prefix, "prefix", "auto", "When to show the pod/container prefix. One of: auto|always|never")
 	flags.StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Only one of since-time / since may be used.")
-	flags.StringVar(&o.color, "color", "auto", "Colorize the output. One of: auto|always|never")
+	flags.StringVar(&o.color, "color", "auto", "Colorize the output. One of: auto|always|never|on|off|yes|no")
 	flags.DurationVar(&o.sinceSeconds, "since", o.sinceSeconds, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
 	flags.StringVar(&o.nodeName, "node-name", "", "The name of the node that pods running on")
 	flags.StringVarP(&o.queryStr, "query", "q", "", "Filter logs by query DSL (e.g. 'error and fatal', 'err or warn', '\"error code\" and timeout')")

--- a/options.go
+++ b/options.go
@@ -37,6 +37,19 @@ type Options struct {
 	containerNamePattern *regexp.Regexp
 }
 
+func normalizeColor(color string) (string, error) {
+	switch color {
+	case "auto":
+		return "auto", nil
+	case "always", "on", "yes":
+		return "always", nil
+	case "never", "off", "no":
+		return "never", nil
+	default:
+		return "", fmt.Errorf("unknown value of flag `color`: %s", color)
+	}
+}
+
 func (o *Options) Complete(getter genericclioptions.RESTClientGetter, args []string) error {
 	o.restClientGetter = getter
 
@@ -53,10 +66,9 @@ func (o *Options) Complete(getter genericclioptions.RESTClientGetter, args []str
 		}
 	}
 
-	switch o.color {
-	case "auto", "always", "never":
-	default:
-		return fmt.Errorf("unknown value of flag `color`: %s", o.color)
+	o.color, err = normalizeColor(o.color)
+	if err != nil {
+		return err
 	}
 
 	switch o.prefix {

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestNormalizeColor(t *testing.T) {
+	cases := map[string]struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		"auto":            {input: "auto", want: "auto"},
+		"always":          {input: "always", want: "always"},
+		"never":           {input: "never", want: "never"},
+		"on maps always":  {input: "on", want: "always"},
+		"yes maps always": {input: "yes", want: "always"},
+		"off maps never":  {input: "off", want: "never"},
+		"no maps never":   {input: "no", want: "never"},
+		"invalid":         {input: "bogus", wantErr: true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := normalizeColor(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("normalizeColor(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -91,7 +91,7 @@ __kt_get_resource_namespace()
 }
 __kt_parse_color()
 {
-    local kt_out=('auto' 'never' 'always')
+    local kt_out=('auto' 'never' 'always' 'on' 'off' 'yes' 'no')
     COMPREPLY+=( $( compgen -W "${kt_out[*]}" -- "$cur" ) )
 }
 __kt_abort() {


### PR DESCRIPTION
## Summary
- Add `on`/`yes` as aliases for `always` and `off`/`no` as aliases for `never` in the `--color` flag
- Extract `normalizeColor()` to map aliases to canonical values during option completion
- Update shell completion and help text to include the new values

## Test plan
- [x] `go test ./...` passes
- [x] Unit tests cover all new aliases and invalid input

🤖 Generated with [Claude Code](https://claude.com/claude-code)